### PR TITLE
Magic links

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,60 @@ try {
 }
 ```
 
+
+### Magic Links
+
+Magic links are secure, one-time use URLs that allow Healthcare Professionals (HCPs) to quickly sign in or verify their identity without entering credentials. This package now supports generating magic links for HCPs using the Healthcare Authenticator (HCA) API.
+
+To create magic links, use the `MagicLink` class by providing your `client_id`, `api_key`, and `redirect` URI. You then call the `createLinks` method with an array of recipients.
+
+Each recipient must include the following fields:
+- `onekey_id` (string): The OneKey identifier of the HCP.
+- `email` (string): The email address of the HCP.
+- `locale` (string): The locale/language code (e.g., 'en-US', 'it-IT').
+
+You can also specify the expiry time for the links in minutes.
+
+The `createLinks` method returns a `MagicLinkResult` object containing collections of successful and failed links.
+
+Example usage:
+
+```php
+use RedSnapper\SocialiteProviders\HealthCareAuthenticator\MagicLink;
+
+$magicLink = new MagicLink(
+    clientId: config('services.hca.client_id'),
+    apiKey: config('services.hca.api_key'),
+    redirect: config('services.hca.redirect'),
+);
+
+$recipients = [
+    ['onekey_id' => '123456', 'email' => 'hcp1@example.com', 'locale' => 'en-US'],
+    ['onekey_id' => '789012', 'email' => 'hcp2@example.com', 'locale' => 'it-IT'],
+];
+
+$result = $magicLink->createLinks($recipients, expiryMinutes: 60);
+```
+
+You can iterate over successful and failed links as follows:
+
+```php
+foreach ($result->successful() as $link) {
+    // $link is a GeneratedMagicLink DTO
+    echo "Magic link for {$link->accountEmail}: {$link->url}\n";
+}
+
+foreach ($result->failed() as $failed) {
+    // $failed is a FailedMagicLink DTO
+    echo "Failed to create link for {$failed->requestEmail}: {$failed->error}\n";
+}
+```
+
+Both successful and failed links are returned as lightweight Data Transfer Objects (DTOs):
+- `GeneratedMagicLink` for successful links.
+- `FailedMagicLink` for failed link creation attempts.
+
+
 ### Testing
 
 ```bash

--- a/src/Exceptions/MagicLinkClientException.php
+++ b/src/Exceptions/MagicLinkClientException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace RedSnapper\SocialiteProviders\HealthCareAuthenticator\Exceptions;
+
+class MagicLinkClientException extends MagicLinkException
+{
+
+}

--- a/src/Exceptions/MagicLinkConnectionException.php
+++ b/src/Exceptions/MagicLinkConnectionException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace RedSnapper\SocialiteProviders\HealthCareAuthenticator\Exceptions;
+
+class MagicLinkConnectionException extends MagicLinkException
+{
+
+}

--- a/src/Exceptions/MagicLinkException.php
+++ b/src/Exceptions/MagicLinkException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace RedSnapper\SocialiteProviders\HealthCareAuthenticator\Exceptions;
+
+class MagicLinkException extends \Exception
+{
+
+}

--- a/src/Exceptions/MagicLinkServerException.php
+++ b/src/Exceptions/MagicLinkServerException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace RedSnapper\SocialiteProviders\HealthCareAuthenticator\Exceptions;
+
+class MagicLinkServerException extends MagicLinkException
+{
+
+}

--- a/src/MagicLink/FailedMagicLink.php
+++ b/src/MagicLink/FailedMagicLink.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace RedSnapper\SocialiteProviders\HealthCareAuthenticator\MagicLink;
+
+class FailedMagicLink
+{
+    public function __construct(
+        public string $onekeyId,
+        public string $requestEmail,
+        public string $error
+    ) {}
+}

--- a/src/MagicLink/GeneratedMagicLink.php
+++ b/src/MagicLink/GeneratedMagicLink.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace RedSnapper\SocialiteProviders\HealthCareAuthenticator\MagicLink;
+
+
+class GeneratedMagicLink
+{
+    public function __construct(
+        public string $onekeyId,
+        public string $accountEmail,
+        public string $url,
+        public string $requestEmail
+    ) {}
+}

--- a/src/MagicLink/MagicLink.php
+++ b/src/MagicLink/MagicLink.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace RedSnapper\SocialiteProviders\HealthCareAuthenticator\MagicLink;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+use RedSnapper\SocialiteProviders\HealthCareAuthenticator\Exceptions\MagicLinkClientException;
+use RedSnapper\SocialiteProviders\HealthCareAuthenticator\Exceptions\MagicLinkConnectionException;
+use RedSnapper\SocialiteProviders\HealthCareAuthenticator\Exceptions\MagicLinkException;
+use RedSnapper\SocialiteProviders\HealthCareAuthenticator\Exceptions\MagicLinkServerException;
+
+class MagicLink
+{
+
+    private string|null $clientId;
+
+    private string|null $apiKey;
+
+    private string|null $redirectUrl;
+
+    public function __construct(?string $clientId = null, ?string $apiKey = null,?string $redirectUrl = null)
+    {
+        $this->clientId = $clientId ?? config('services.hca.client_id');
+        $this->apiKey = $apiKey ?? config('services.hca.api_key');
+        $this->redirectUrl = $redirectUrl ?? config('services.hca.redirect');
+    }
+
+    public function createLinks(array $recipients, int $durationMinutes = 60): MagicLinkResult
+    {
+
+        $durationSeconds = $durationMinutes * 60;
+        $redirect = $this->formatRedirectUrl($this->redirectUrl);
+
+        try {
+            $response = Http::withHeaders([
+                'Ocp-Apim-Subscription-Key' => $this->apiKey,
+            ])->post('https://apim-prod-westeu-onekey.azure-api.net/api/hca/link/b2b/', [
+                'links' => [
+                    'recipients'         => $recipients,
+                    'client_id'          => $this->clientId,
+                    'redirect_uri'       => $redirect,
+                    'scope'              => 'openid https://auth.onekeyconnect.com/x/profile.extended',
+                    'response_mode'      => 'query',
+                    'response_type'      => 'code',
+                    'duration_in_second' => $durationSeconds,
+                ],
+            ]);
+
+            $response->throw();
+
+            // Map API results to MagicLinkResult
+            return $this->mapResponseToResult($response->json());
+
+        } catch (\Illuminate\Http\Client\ConnectionException $e) {
+            throw new MagicLinkConnectionException($e->getMessage(), $e->getCode(), $e);
+        } catch (\Illuminate\Http\Client\RequestException $e) {
+            $status = $e->response?->status() ?? 0;
+
+            if ($status >= 400 && $status < 500) {
+                throw new MagicLinkClientException($e->getMessage(), $status, $e);
+            } elseif ($status >= 500) {
+                throw new MagicLinkServerException($e->getMessage(), $status, $e);
+            } else {
+                throw new MagicLinkException($e->getMessage(), $status, $e);
+            }
+        }
+
+    }
+
+    protected function mapResponseToResult(array $apiResults): MagicLinkResult
+    {
+
+        $success = collect($apiResults['links'])->map(function ($item) {
+            return new GeneratedMagicLink(
+                onekeyId: $item['onekey_id'],
+                accountEmail: $item['account_email'],
+                url: $item['url'],
+                requestEmail: $item['request_email']
+            );
+        });
+
+        $failed = collect($apiResults['failed_links'])->map(function ($item) {
+            return new FailedMagicLink(
+                onekeyId: $item['onekey_id'],
+                requestEmail: $item['request_email'],
+                error: $item['error']
+            );
+        });
+
+
+        return new MagicLinkResult($success->all(), $failed->all());
+    }
+
+
+    /**
+     * Normalize relative redirect URLs to absolute URLs.
+     */
+    protected function formatRedirectUrl(string $redirect): string
+    {
+        return Str::startsWith($redirect, '/')
+            ? app('url')->to($redirect)
+            : $redirect;
+    }
+
+}

--- a/src/MagicLink/MagicLinkResult.php
+++ b/src/MagicLink/MagicLinkResult.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace RedSnapper\SocialiteProviders\HealthCareAuthenticator\MagicLink;
+
+class MagicLinkResult
+{
+    /** @var GeneratedMagicLink[] */
+    public array $success;
+    /** @var FailedMagicLink[] */
+    public array $failed;
+
+    public function __construct(array $success, array $failed)
+    {
+        $this->success = $success;
+        $this->failed = $failed;
+    }
+}

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -5,6 +5,7 @@ namespace RedSnapper\SocialiteProviders\HealthCareAuthenticator;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 
 class Provider extends AbstractProvider
@@ -119,5 +120,32 @@ class Provider extends AbstractProvider
             'trustLevel' => Arr::get($user, 'trustLevel'),
         ]);
 
+    }
+
+    protected function getTokenFields($code)
+    {
+        $fields = [
+            'grant_type' => 'authorization_code',
+            'client_id' => $this->clientId,
+            'client_secret' => $this->clientSecret,
+            'code' => $code,
+            'redirect_uri' => $this->redirectUrl,
+        ];
+
+        if ($this->request->has('verifier')) {
+            $fields['code_verifier'] = $this->request->get('verifier');
+            unset($fields['client_secret']);
+        }
+
+        return array_merge($fields, $this->parameters);
+    }
+
+    protected function hasInvalidState()
+    {
+        if($this->request->has('verifier')) {
+            return false;
+        }
+
+        return parent::hasInvalidState();
     }
 }

--- a/tests/MagicLink/MagicLinkTest.php
+++ b/tests/MagicLink/MagicLinkTest.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace RedSnapper\SocialiteProviders\HealthCareAuthenticator\Tests\MagicLink;
+
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+use RedSnapper\SocialiteProviders\HealthCareAuthenticator\Exceptions\MagicLinkClientException;
+use RedSnapper\SocialiteProviders\HealthCareAuthenticator\Exceptions\MagicLinkConnectionException;
+use RedSnapper\SocialiteProviders\HealthCareAuthenticator\Exceptions\MagicLinkServerException;
+use RedSnapper\SocialiteProviders\HealthCareAuthenticator\MagicLink\GeneratedMagicLink;
+use RedSnapper\SocialiteProviders\HealthCareAuthenticator\MagicLink\MagicLink;
+use RedSnapper\SocialiteProviders\HealthCareAuthenticator\Tests\TestCase;
+
+class MagicLinkTest extends TestCase
+{
+    protected string $clientId = '1234';
+    protected string $apiKey = 'apikey';
+    protected string $redirectUrl = 'https://example.com/callback';
+
+    public function test_successful_magic_links()
+    {
+        $recipients = [
+            ['onekey_id' => 'ABC123', 'email' => 'user@example.com', 'locale' => 'en-US']
+        ];
+
+        $responseData = [
+            'links' => [
+                [
+                    'onekey_id' => 'ABC123',
+                    'request_email' => 'user@example.com',
+                    'account_email'=>'account@example.com',
+                    'url' => 'https://magiclink.test/abc123',
+                    'expiry' => now()->addHour()->toIso8601String()
+                ]
+            ],
+            'failed_links'=>[]
+        ];
+
+        Http::fake([
+            '/b2b' => Http::response($responseData)
+        ]);
+
+        $magicLink = new MagicLink($this->clientId, $this->apiKey, '/callback');
+        $result = $magicLink->createLinks($recipients,30);
+
+
+        Http::assertSent(function (Request $request) {
+
+            $this->assertEquals([$this->apiKey],$request->header('Ocp-Apim-Subscription-Key'));
+            $this->assertEquals($this->clientId,$request->data()['links']['client_id']);
+            $this->assertEquals('http://localhost/callback',$request->data()['links']['redirect_uri']);
+            $this->assertEquals(30*60,$request->data()['links']['duration_in_second']);;
+
+           return true;
+
+        });
+
+        $this->assertCount(1, $result->success);
+        $this->assertCount(0, $result->failed);
+
+        $link = $result->success[0];
+        $this->assertInstanceOf(GeneratedMagicLink::class, $link);
+        $this->assertEquals('ABC123', $link->onekeyId);
+        $this->assertEquals('user@example.com', $link->requestEmail);
+        $this->assertEquals('account@example.com', $link->accountEmail);
+        $this->assertEquals('https://magiclink.test/abc123', $link->url);
+
+    }
+
+    public function test_partial_failure()
+    {
+        $recipients = [
+            ['onekey_id' => 'ABC123', 'email' => 'user1@example.com', 'locale' => 'en-US'],
+            ['onekey_id' => 'DEF456', 'email' => 'user2@example.com', 'locale' => 'en-US']
+        ];
+
+        $responseData = [
+            'links'=>[],
+            'failed_links' => [
+                [
+                    'onekey_id' => 'DEF456',
+                    'request_email' => 'user2@example.com',
+                    'error' => 'Invalid email'
+                ]
+            ]
+        ];
+
+        Http::fake([
+            '/b2b' => Http::response($responseData, 200)
+        ]);
+
+        $magicLink = new MagicLink($this->clientId, $this->apiKey, $this->redirectUrl);
+        $result = $magicLink->createLinks($recipients);
+
+        $this->assertCount(0, $result->success);
+        $this->assertCount(1, $result->failed);
+
+        $this->assertEquals('DEF456', $result->failed[0]->onekeyId);
+        $this->assertEquals('user2@example.com', $result->failed[0]->requestEmail);
+        $this->assertEquals('Invalid email', $result->failed[0]->error);
+    }
+
+    public function test_client_error_throws_exception()
+    {
+        Http::fake([
+            '/b2b' => Http::response([], 400)
+        ]);
+
+        $magicLink = new MagicLink($this->clientId, $this->apiKey, $this->redirectUrl);
+
+        $this->expectException(MagicLinkClientException::class);
+
+        $magicLink->createLinks([['onekey_id' => 'ABC123', 'email' => 'user@example.com']]);
+    }
+
+    public function test_server_error_throws_exception()
+    {
+        Http::fake([
+            '/b2b' => Http::response([], 500)
+        ]);
+
+        $magicLink = new MagicLink($this->clientId, $this->apiKey, $this->redirectUrl);
+
+        $this->expectException(MagicLinkServerException::class);
+
+        $magicLink->createLinks([['onekey_id' => 'ABC123', 'email' => 'user@example.com']]);
+    }
+
+    public function test_connection_error_throws_exception()
+    {
+        Http::fake([
+            '/b2b' => Http::failedConnection()
+        ]);
+
+        $magicLink = new MagicLink($this->clientId, $this->apiKey, $this->redirectUrl);
+
+        $this->expectException(MagicLinkConnectionException::class);
+
+        $magicLink->createLinks([['onekey_id' => 'ABC123', 'email' => 'user@example.com']]);
+    }
+
+    public function test_constructor_uses_config_defaults_in_request()
+    {
+        // Arrange: set config values
+        Config::set('services.hca.client_id', 'config-client-id');
+        Config::set('services.hca.api_key', 'config-api-key');
+        Config::set('services.hca.redirect', '/callback');
+
+        Http::fake([
+            '/b2b' => Http::response(['links' => [], 'failed_links' => []], 200)
+        ]);
+
+        $magicLink = new MagicLink(); // no params, should fall back to config
+        $magicLink->createLinks([]);
+
+        // Assert that the request used the config values
+        Http::assertSent(function ($request) {
+            return $request->data()['links']['client_id'] === 'config-client-id'
+                && $request->header('Ocp-Apim-Subscription-Key')[0] === 'config-api-key'
+                && $request->data()['links']['redirect_uri'] === url('/callback');
+        });
+    }
+
+}


### PR DESCRIPTION
### 1. Overview

We are extending the package to support HCA Magic Link authentication alongside the existing OAuth 2.0 state-based authentication flow.

The goal is to enable developers to:

- Generate magic links via HCA’s Magic Link API.
- Handle both normal OAuth and magic link callbacks in a unified way.
- Correctly exchange tokens based on whether the callback contains a state (normal flow) or code_verifier (magic link PKCE flow)

### 2. Motivation

Currently, the package only supports the state-based OAuth 2.0 flow:

- Authorization URL generated by the client.
- Callback contains code + state.
- /token request includes client_secret.

HCA’s Magic Link API, however, uses PKCE:

- The callback contains code + verifier.
-  /token request must not include client_secret.

Without these changes, developers cannot easily authenticate users using HCA’s magic link feature.

### 3. Changes to Callback Handling

We will modify the callback handling logic so that the package can process both flows using one callback route:
Current behaviour:

- Always expects state parameter.
- Validates state.
- Exchanges code for token with client_secret.

New behaviour:

     If state is present:
        Validate state.
        Exchange code with /token including client_secret.
    Else if verifier is present:
        Exchange code with /token excluding client_secret.
        Include code_verifier in the request.
    Else:
        Throw InvalidState indicating no valid parameters were found.

### 4. New MagicLink Class
Purpose

Encapsulates creation of magic links via the HCA Magic Link API.
Location

src/MagicLink.php
Responsibilities

    Send POST request to HCA Magic Link API endpoint.
    Accept input parameters for link creation (e.g., Onekey IDs, expiration, email).
    Handle HTTP errors (network, 4xx, 5xx).

    Return:

        successful links (with required metadata)
        failed links (with error reasons)