### PR TITLE
Update magic link endpoint to api.healthcaresdks.com

### DIFF
--- a/src/MagicLink/MagicLink.php
+++ b/src/MagicLink/MagicLink.php
@@ -34,7 +34,7 @@ class MagicLink
         try {
             $response = Http::withHeaders([
                 'Ocp-Apim-Subscription-Key' => $this->apiKey,
-            ])->post('https://apim-prod-westeu-onekey.azure-api.net/api/hca/link/b2b/', [
+            ])->post('https://api.healthcaresdks.com/api/hca/link/b2b', [
                 'links' => [
                     'recipients'         => $recipients,
                     'client_id'          => $this->clientId,

--- a/tests/MagicLink/MagicLinkTest.php
+++ b/tests/MagicLink/MagicLinkTest.php
@@ -39,7 +39,7 @@ class MagicLinkTest extends TestCase
         ];
 
         Http::fake([
-            '/b2b/' => Http::response($responseData)
+            'api.healthcaresdks.com/*' => Http::response($responseData)
         ]);
 
         $magicLink = new MagicLink($this->clientId, $this->apiKey, '/callback');
@@ -88,7 +88,7 @@ class MagicLinkTest extends TestCase
         ];
 
         Http::fake([
-            '/b2b/' => Http::response($responseData, 200)
+            'api.healthcaresdks.com/*' => Http::response($responseData, 200)
         ]);
 
         $magicLink = new MagicLink($this->clientId, $this->apiKey, $this->redirectUrl);
@@ -105,7 +105,7 @@ class MagicLinkTest extends TestCase
     public function test_client_error_throws_exception()
     {
         Http::fake([
-            '/b2b/' => Http::response([], 400)
+            'api.healthcaresdks.com/*' => Http::response([], 400)
         ]);
 
         $magicLink = new MagicLink($this->clientId, $this->apiKey, $this->redirectUrl);
@@ -118,7 +118,7 @@ class MagicLinkTest extends TestCase
     public function test_server_error_throws_exception()
     {
         Http::fake([
-            '/b2b/' => Http::response([], 500)
+            'api.healthcaresdks.com/*' => Http::response([], 500)
         ]);
 
         $magicLink = new MagicLink($this->clientId, $this->apiKey, $this->redirectUrl);
@@ -131,7 +131,7 @@ class MagicLinkTest extends TestCase
     public function test_connection_error_throws_exception()
     {
         Http::fake([
-            '/b2b/' => Http::failedConnection()
+            'api.healthcaresdks.com/*' => Http::failedConnection()
         ]);
 
         $magicLink = new MagicLink($this->clientId, $this->apiKey, $this->redirectUrl);
@@ -149,7 +149,7 @@ class MagicLinkTest extends TestCase
         Config::set('services.hca.redirect', '/callback');
 
         Http::fake([
-            '/b2b/' => Http::response(['links' => [], 'failed_links' => []], 200)
+            'api.healthcaresdks.com/*' => Http::response(['links' => [], 'failed_links' => []], 200)
         ]);
 
         $magicLink = new MagicLink(); // no params, should fall back to config


### PR DESCRIPTION
## Summary
- The B2B magic link endpoint has moved from the Azure APIM host to `api.healthcaresdks.com/api/hca/link/b2b`.
- Updates the production URL in `MagicLink::createLinks()` and the matching `Http::fake()` host pattern in the test suite so the existing tests continue to cover the new endpoint.

## Test plan
- [x] `vendor/bin/phpunit tests/MagicLink/MagicLinkTest.php` (6 tests, 21 assertions) passes locally
- [x] Verified end-to-end against the live service from the consuming app (single magic link generated successfully via the admin UI and also via Postman against the new host)