### PR TITLE
OHP-2128 - Handle token exchange responses with no access token

### DIFF
--- a/src/MissingAccessTokenException.php
+++ b/src/MissingAccessTokenException.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace RedSnapper\SocialiteProviders\HealthCareAuthenticator;
+
+class MissingAccessTokenException extends HealthCareAuthenticatorRequestException
+{
+    protected ?int $status;
+
+    protected ?string $rawBody;
+
+    public function __construct(
+        ?int $status = null,
+        ?string $rawBody = null,
+        string $message = 'Healthcare Authenticator did not return an access token.',
+        int $code = 0,
+        ?\Throwable $previous = null
+    ) {
+        $this->status = $status;
+        $this->rawBody = $rawBody;
+
+        parent::__construct($message, $code, $previous);
+    }
+
+    public function getStatus(): ?int
+    {
+        return $this->status;
+    }
+
+    public function getRawBody(): ?string
+    {
+        return $this->rawBody;
+    }
+}

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -2,10 +2,10 @@
 
 namespace RedSnapper\SocialiteProviders\HealthCareAuthenticator;
 
+use GuzzleHttp\RequestOptions;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Http;
-use Illuminate\Support\Facades\Log;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 
 class Provider extends AbstractProvider
@@ -43,9 +43,34 @@ class Provider extends AbstractProvider
         return 'https://auth.hcn.health/hca/token';
     }
 
+    public function getAccessTokenResponse($code)
+    {
+        $response = $this->getHttpClient()->post($this->getTokenUrl(), [
+            RequestOptions::HEADERS => $this->getTokenHeaders($code),
+            RequestOptions::FORM_PARAMS => $this->getTokenFields($code),
+        ]);
+
+        $body = (string) $response->getBody();
+        $decoded = json_decode($body, true);
+
+        // A successful (2xx) token exchange must contain an access token. When it
+        // does not, the upstream provider has responded off-spec — an error payload
+        // returned with a 200, or an empty/non-JSON body. Capture the raw status and
+        // body for diagnostics and surface it as an expected exception, rather than
+        // letting a null token reach the string-typed getUserInfoByToken() and blow
+        // up as a fatal TypeError. (4xx/5xx responses throw in Guzzle before here.)
+        if (blank(Arr::get(is_array($decoded) ? $decoded : [], 'access_token'))) {
+            throw new MissingAccessTokenException(
+                status: $response->getStatusCode(),
+                rawBody: $body,
+            );
+        }
+
+        return $decoded;
+    }
+
     protected function getUserByToken($token)
     {
-
         $account = $this->getUserInfoByToken($token, '/account');
         $profile = $this->getUserById($account['user_id']);
 
@@ -86,7 +111,7 @@ class Provider extends AbstractProvider
                     previous: $e
                 );
             }
-            
+
             // Re-throw other exceptions
             throw $e;
         }
@@ -142,7 +167,7 @@ class Provider extends AbstractProvider
 
     protected function hasInvalidState()
     {
-        if($this->request->has('verifier')) {
+        if ($this->request->has('verifier')) {
             return false;
         }
 

--- a/tests/ProviderTest.php
+++ b/tests/ProviderTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\Attributes\Test;
 use Psr\Http\Message\ResponseInterface;
 use RedSnapper\SocialiteProviders\HealthCareAuthenticator\HealthCareAuthenticatorRequestException;
 use RedSnapper\SocialiteProviders\HealthCareAuthenticator\HealthCareAuthenticatorUser;
+use RedSnapper\SocialiteProviders\HealthCareAuthenticator\MissingAccessTokenException;
 use RedSnapper\SocialiteProviders\HealthCareAuthenticator\Provider;
 use RedSnapper\SocialiteProviders\HealthCareAuthenticator\UserNotFoundException;
 use SocialiteProviders\Manager\Config;
@@ -135,14 +136,14 @@ class ProviderTest extends TestCase
     {
         $request = new Request([
             'code' => 'auth-code',
-            'verifier' => 'verifier'
+            'verifier' => 'verifier',
         ]);
         $request->setLaravelSession($this->app->make('session')->driver('array'));
 
         // Mock access token response
-        $accessTokenResponse = $this->mock(\Psr\Http\Message\ResponseInterface::class);
+        $accessTokenResponse = $this->mock(ResponseInterface::class);
         $accessTokenResponse->allows('getBody')->andReturns(
-            \GuzzleHttp\Psr7\Utils::streamFor(json_encode(['access_token' => 'fake-token']))
+            Utils::streamFor(json_encode(['access_token' => 'fake-token']))
         );
 
         Http::fake([
@@ -150,9 +151,9 @@ class ProviderTest extends TestCase
         ]);
 
         // Mock basic account response
-        $basicAccountResponse = $this->mock(\Psr\Http\Message\ResponseInterface::class);
+        $basicAccountResponse = $this->mock(ResponseInterface::class);
         $basicAccountResponse->allows('getBody')->andReturns(
-            \GuzzleHttp\Psr7\Utils::streamFor(json_encode([
+            Utils::streamFor(json_encode([
                 'user_id' => 'abc123',
                 'email' => 'test@example.com',
                 'uci' => 'signup_ucis',
@@ -160,7 +161,7 @@ class ProviderTest extends TestCase
         );
 
         // Mock Guzzle
-        $guzzle = $this->mock(\GuzzleHttp\Client::class);
+        $guzzle = $this->mock(Client::class);
 
         // Ensure the `post` call (token exchange) happens with code_verifier
         $guzzle->expects('post')
@@ -168,6 +169,7 @@ class ProviderTest extends TestCase
                 $this->assertArrayNotHasKey('client_secret', $options['form_params']);
                 $this->assertArrayHasKey('code_verifier', $options['form_params']);
                 $this->assertEquals('verifier', $options['form_params']['code_verifier']);
+
                 return true;
             })
             ->andReturn($accessTokenResponse);
@@ -194,6 +196,77 @@ class ProviderTest extends TestCase
         $request = new Request(['error' => 'denied', 'error_description' => 'User denied access']);
         $provider = new Provider($request, 'client_id', 'client_secret', 'redirect');
         $provider->user();
+    }
+
+    #[Test]
+    public function it_throws_a_missing_access_token_exception_when_the_token_response_has_no_access_token()
+    {
+        $request = new Request(['code' => 'auth-code', 'state' => 'state']);
+        $session = $this->app->make('session')->driver('array');
+        $session->put('state', 'state');
+        $request->setLaravelSession($session);
+
+        // A 2xx token exchange that returns no access_token (e.g. an off-spec
+        // error payload). Previously this produced a fatal TypeError when the
+        // null token reached the string-typed getUserInfoByToken().
+        $rawBody = json_encode([
+            'error' => 'invalid_grant',
+            'error_description' => 'Authorization code expired.',
+        ]);
+
+        $accessTokenResponse = $this->mock(ResponseInterface::class);
+        $accessTokenResponse->allows('getBody')->andReturns(Utils::streamFor($rawBody));
+        $accessTokenResponse->allows('getStatusCode')->andReturns(200);
+
+        $guzzle = $this->mock(Client::class);
+        $guzzle->expects('post')->andReturns($accessTokenResponse);
+        $guzzle->expects('get')->never();
+
+        $provider = new Provider($request, 'client_id', 'client_secret', 'redirect');
+        $provider->setHttpClient($guzzle);
+
+        try {
+            $provider->user();
+            $this->fail('Expected MissingAccessTokenException was not thrown.');
+        } catch (MissingAccessTokenException $e) {
+            $this->assertInstanceOf(HealthCareAuthenticatorRequestException::class, $e);
+            $this->assertEquals('Healthcare Authenticator did not return an access token.', $e->getMessage());
+            $this->assertEquals(200, $e->getStatus());
+            $this->assertEquals($rawBody, $e->getRawBody());
+        }
+    }
+
+    #[Test]
+    public function it_throws_a_missing_access_token_exception_when_the_token_response_body_is_not_json()
+    {
+        $request = new Request(['code' => 'auth-code', 'state' => 'state']);
+        $session = $this->app->make('session')->driver('array');
+        $session->put('state', 'state');
+        $request->setLaravelSession($session);
+
+        // A 2xx response whose body cannot be decoded to a token (e.g. a proxy
+        // timeout page returned with a 200). json_decode yields null, so the
+        // decoded credentialsResponseBody would tell us nothing — the raw body
+        // is what we retain for diagnostics.
+        $rawBody = '<html><body>Gateway Timeout</body></html>';
+
+        $accessTokenResponse = $this->mock(ResponseInterface::class);
+        $accessTokenResponse->allows('getBody')->andReturns(Utils::streamFor($rawBody));
+        $accessTokenResponse->allows('getStatusCode')->andReturns(200);
+
+        $guzzle = $this->mock(Client::class);
+        $guzzle->expects('post')->andReturns($accessTokenResponse);
+        $guzzle->expects('get')->never();
+
+        $provider = new Provider($request, 'client_id', 'client_secret', 'redirect');
+        $provider->setHttpClient($guzzle);
+
+        try {
+            $provider->user();
+            $this->fail('Expected MissingAccessTokenException was not thrown.');
+        } catch (MissingAccessTokenException $e) {
+            $this->assertEquals($rawBody, $e->getRawBody());
+        }
     }
 
     #[Test]


### PR DESCRIPTION
## Problem

`Provider::getUserInfoByToken()` was receiving a `null` `$token` and fataling with a `TypeError` (the argument is typed `string`) — [OHP-2128](https://redsnapper.atlassian.net/browse/OHP-2128).

Root cause: Socialite's `user()` flow parses the access token with `Arr::get($response, 'access_token')`, which returns `null` when the token endpoint responds **2xx with no access token**. Guzzle throws on 4xx/5xx, so the only way to reach here with a null token is a spec-compliant-looking success response that actually carries no token — an OAuth error payload returned with a `200`, or an empty/non-JSON body that decodes to `null`. That `null` then hit the `string`-typed `getUserInfoByToken()` and became a fatal error.

A real callback that triggered this was an externally-initiated PKCE flow (`code` + `verifier` present, no `error` param), so the guard on the callback query string didn't catch it.

## Change

- Override `getAccessTokenResponse()` to detect a missing/blank access token at the earliest point, while we still hold the **raw** HTTP response.
- Throw a new `MissingAccessTokenException` (extends `HealthCareAuthenticatorRequestException`, so existing generic catches still handle it gracefully) carrying the upstream **status** and **raw body** via `getStatus()` / `getRawBody()` for diagnostics.

Consumers can now catch this and redirect/log instead of fataling. The raw body is retained deliberately — the decoded `credentialsResponseBody` is `null` when the body isn't JSON, so it would tell us nothing about what the upstream actually returned.

## Tests

- `it_throws_a_missing_access_token_exception_when_the_token_response_has_no_access_token` — token-less 200 payload.
- `it_throws_a_missing_access_token_exception_when_the_token_response_body_is_not_json` — non-JSON 200 body.

Full suite: 16 tests / 78 assertions passing, Pint clean.

## Next steps (separate PR)

The Otsuka HCP Portal consumer will catch `MissingAccessTokenException`, log at `error` with the captured payload, and redirect to login. That depends on this being tagged (e.g. `v0.7.3`) and pulled in.

[OHP-2128]: https://redsnapper.atlassian.net/browse/OHP-2128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ